### PR TITLE
Fixed typo

### DIFF
--- a/src/auth/server.py
+++ b/src/auth/server.py
@@ -38,7 +38,7 @@ def login():
         return "invalide credentials", 401
 
 
-@server.route("/validate", method=["POST"])
+@server.route("/validate", methods=["POST"])
 def validate():
     encoded_jwt = request.headers["Authorization"]
 


### PR DESCRIPTION
The argument for the @server.route() should be in plural -> `methods` instead of `method`.