### PR TITLE
Ensure MYSQL port is always evaluated as integer

### DIFF
--- a/src/auth/server.py
+++ b/src/auth/server.py
@@ -10,7 +10,7 @@ server.config["MYSQL_HOST"] = os.environ.get("MYSQL_HOST")
 server.config["MYSQL_USER"] = os.environ.get("MYSQL_USER")
 server.config["MYSQL_PASSWORD"] = os.environ.get("MYSQL_PASSWORD")
 server.config["MYSQL_DB"] = os.environ.get("MYSQL_DB")
-server.config["MYSQL_PORT"] = os.environ.get("MYSQL_PORT")
+server.config["MYSQL_PORT"] = int(os.environ.get("MYSQL_PORT"))
 
 
 @server.route("/login", methods=["POST"])


### PR DESCRIPTION
For certain versions of MYSQL it will fail to connect if the port is enterprated as a string and will throw a status 500 error when connecting to the database 

```python
# Error occurs here for reference if others encounter the same issue
cur = mysql.connection.cursor()
```